### PR TITLE
Fix PyPI rendering of Markdown description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,25 @@
-# Change Log
+## Change Log
 
 Notable changes to this project will be documented in this file.
 
-## Version History
+### Version History
 
-### 0.2.0
+#### 19.9.2
+
+- Fix markdown displayed on PyPI.
+
+#### 19.9.1
+
+- Adopted CalVer for package versioning.
+- Initial functionality release.
+- Clean up type annotation to remove all Mypy errors.
+- Add Mypy type check to CI.
+- Improve unit test code coverage.
+
+#### 0.2.0
 
 - Added basic functionality.
 
-### 0.0.1
+#### 0.0.1
 
 - Project created.

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ if __name__ == "__main__":
         name="gestalt",
         description="gestalt is a Python application framework for building distributed systems",
         long_description=get_long_description(),
+        long_description_content_type="text/markdown",
         license="MIT license",
         url="https://github.com/claws/gestalt",
         version=get_version(),

--- a/src/gestalt/__init__.py
+++ b/src/gestalt/__init__.py
@@ -2,4 +2,4 @@
 Gestalt is a Python application framework for building distributed systems.
 """
 
-__version__ = "19.9.1"
+__version__ = "19.9.2"


### PR DESCRIPTION
Fix the poor rendering of the project description on PyPI by specifying the content type of the description text as Markdown.

Take this opportunity to also update the change log.