### PR TITLE
improve error reporting and minor cleanups

### DIFF
--- a/examples/amq/rpc/rpc-client.py
+++ b/examples/amq/rpc/rpc-client.py
@@ -20,11 +20,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="AMQP RPC Client Example")
     parser.add_argument(
-        "--amqp-url",
-        metavar="<url>",
-        type=str,
-        default="amqp://guest:guest@localhost:5672/",
-        help="The AMQP URL",
+        "--amqp-url", metavar="<url>", type=str, default=None, help="The AMQP URL"
     )
     parser.add_argument(
         "--exchange-name",

--- a/examples/amq/rpc/rpc-server.py
+++ b/examples/amq/rpc/rpc-server.py
@@ -16,11 +16,7 @@ logger = logging.getLogger(__name__)
 def get_options():
     parser = argparse.ArgumentParser(description="AMQP RPC Server Example")
     parser.add_argument(
-        "--amqp-url",
-        metavar="<url>",
-        type=str,
-        default="amqp://guest:guest@localhost:5672/",
-        help="The AMQP URL",
+        "--amqp-url", metavar="<url>", type=str, default=None, help="The AMQP URL"
     )
     parser.add_argument(
         "--exchange-name",

--- a/examples/amq/topic/topic-consumer.py
+++ b/examples/amq/topic/topic-consumer.py
@@ -30,11 +30,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="AMQP Topic Consumer Example")
     parser.add_argument(
-        "--amqp-url",
-        metavar="<url>",
-        type=str,
-        default="amqp://guest:guest@localhost:5672/",
-        help="The AMQP URL",
+        "--amqp-url", metavar="<url>", type=str, default=None, help="The AMQP URL"
     )
     parser.add_argument(
         "--exchange-name",

--- a/examples/amq/topic/topic-producer.py
+++ b/examples/amq/topic/topic-producer.py
@@ -54,11 +54,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="AMQP Topic Producer Example")
     parser.add_argument(
-        "--amqp-url",
-        metavar="<url>",
-        type=str,
-        default="amqp://guest:guest@localhost:5672/",
-        help="The AMQP URL",
+        "--amqp-url", metavar="<url>", type=str, default=None, help="The AMQP URL"
     )
     parser.add_argument(
         "--exchange-name",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
             "brotli": ["brotli"],
         },
         classifiers=[
-            "Development Status :: 3 - Alpha",
+            "Development Status :: 4 - Beta",
             "Intended Audience :: Developers",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",

--- a/src/gestalt/__init__.py
+++ b/src/gestalt/__init__.py
@@ -2,4 +2,4 @@
 Gestalt is a Python application framework for building distributed systems.
 """
 
-__version__ = "19.9.2"
+__version__ = "19.10.0"

--- a/src/gestalt/amq/consumer.py
+++ b/src/gestalt/amq/consumer.py
@@ -102,7 +102,7 @@ class Consumer(object):
             return
         except (AMQPError, ConnectionError) as exc:
             logger.error(f"Connection({self.amqp_url}) {exc}")
-            raise Exception(f"Can't connect to {self.amqp_url}") from None
+            raise Exception(f"Can't connect to {self.amqp_url}") from exc
 
         assert self.connection is not None
         self.channel = await self.connection.channel()

--- a/src/gestalt/amq/producer.py
+++ b/src/gestalt/amq/producer.py
@@ -86,12 +86,9 @@ class Producer(object):
         except asyncio.CancelledError:
             logger.info(f"Connection({self.amqp_url}) cancelled")
             return
-        except (AMQPError, ConnectionError) as error:
-            logger.error(f"Connection({self.amqp_url}) {error}")
-            return
-        except Exception as ex:
-            logger.exception(ex)
-            return
+        except (AMQPError, ConnectionError) as exc:
+            logger.error(f"Connection({self.amqp_url}) {exc}")
+            raise Exception(f"Can't connect to {self.amqp_url}") from exc
 
         assert self.connection is not None
         self.channel = await self.connection.channel()

--- a/src/gestalt/amq/requester.py
+++ b/src/gestalt/amq/requester.py
@@ -125,12 +125,9 @@ class Requester(object):
         except asyncio.CancelledError:
             logger.info(f"Connection({self.amqp_url}) cancelled")
             return
-        except (AMQPError, ConnectionError) as error:
-            logger.error(f"Connection({self.amqp_url}) {error}")
-            return
-        except Exception as ex:
-            logger.exception(ex)
-            return
+        except (AMQPError, ConnectionError) as exc:
+            logger.error(f"Connection({self.amqp_url}) {exc}")
+            raise Exception(f"Can't connect to {self.amqp_url}") from exc
 
         assert self.connection is not None
 

--- a/src/gestalt/amq/responder.py
+++ b/src/gestalt/amq/responder.py
@@ -125,12 +125,9 @@ class Responder(object):
         except asyncio.CancelledError:
             logger.info(f"Connection({self.amqp_url}) cancelled")
             return
-        except (AMQPError, ConnectionError) as error:
-            logger.error(f"Connection({self.amqp_url}) {error}")
-            return
-        except Exception as ex:
-            logger.exception(ex)
-            return
+        except (AMQPError, ConnectionError) as exc:
+            logger.error(f"Connection({self.amqp_url}) {exc}")
+            raise Exception(f"Can't connect to {self.amqp_url}") from exc
 
         assert self.connection is not None
         self.channel = await self.connection.channel()
@@ -226,13 +223,13 @@ class Responder(object):
             await message.reject(requeue=False)
             return
 
-        response_message = Message(  # type: ignore
+        response_message = Message(
             body=payload,
             content_type=content_type,
             content_encoding=content_encoding,
             timestamp=time.time(),
             correlation_id=message.correlation_id,
-            delivery_mode=message.delivery_mode,
+            delivery_mode=message.delivery_mode,  # type: ignore
             headers=headers,
         )
 

--- a/src/gestalt/amq/utils.py
+++ b/src/gestalt/amq/utils.py
@@ -39,7 +39,7 @@ def build_amqp_url(
     """
     user = user if user else os.getenv("RABBITMQ_USER", "guest")
     password = password if password else os.getenv("RABBITMQ_PASS", "guest")
-    host = host if host else os.getenv("RABBITMQ_HOST", "localhost")
+    host = host if host else os.getenv("RABBITMQ_HOST", "127.0.0.1")
     port = port if port else int(os.getenv("RABBITMQ_PORT", "5672"))
     virtual_host = virtual_host if virtual_host else "/"
 

--- a/src/gestalt/runner.py
+++ b/src/gestalt/runner.py
@@ -83,7 +83,9 @@ def run(
     loop.add_signal_handler(SIGTERM, signal_handler, loop, SIGTERM)
 
     def exception_handler(loop, context):
-        logger.exception(f"Caught exception: {context}")
+        exc_msg = context["message"]
+        exc = context["exception"]
+        logger.exception(f"Caught exception: {exc_msg}", exc_info=exc)
         loop.call_soon(loop.stop)
 
     loop.set_exception_handler(exception_handler)

--- a/tests/test_amq_utils.py
+++ b/tests/test_amq_utils.py
@@ -260,30 +260,30 @@ class RabbitmqUtilitiesTestCase(unittest.TestCase):
 
     def test_create_url_without_args(self):
         url = utils.build_amqp_url()
-        self.assertEqual(url, "amqp://guest:guest@localhost:5672//")
+        self.assertEqual(url, "amqp://guest:guest@127.0.0.1:5672//")
 
     def test_create_url_with_connection_attempts(self):
         url = utils.build_amqp_url(connection_attempts=5)
         self.assertEqual(
-            url, "amqp://guest:guest@localhost:5672//?connection_attempts=5"
+            url, "amqp://guest:guest@127.0.0.1:5672//?connection_attempts=5"
         )
 
     def test_create_url_with_heartbeat_interval(self):
         url = utils.build_amqp_url(heartbeat_interval=2)
         self.assertEqual(
-            url, "amqp://guest:guest@localhost:5672//?heartbeat_interval=2"
+            url, "amqp://guest:guest@127.0.0.1:5672//?heartbeat_interval=2"
         )
 
     def test_create_url_with_connection_attempts_andheartbeat_interval(self):
         url = utils.build_amqp_url(connection_attempts=5, heartbeat_interval=2)
         self.assertEqual(
             url,
-            "amqp://guest:guest@localhost:5672//?connection_attempts=5&heartbeat_interval=2",
+            "amqp://guest:guest@127.0.0.1:5672//?connection_attempts=5&heartbeat_interval=2",
         )
 
     def test_create_url_with_virtual_host(self):
         url = utils.build_amqp_url(virtual_host="vhost")
-        self.assertEqual(url, "amqp://guest:guest@localhost:5672/vhost")
+        self.assertEqual(url, "amqp://guest:guest@127.0.0.1:5672/vhost")
 
     def test_create_url_without_virtual_host(self):
         url = utils.build_amqp_url(


### PR DESCRIPTION
The main aim of this merge request is to fix bug that prevented an exception being raised when AMQP connections failed to connect to RMQ broker when they were started. Instead, the error only triggered a log message.

While resolving this bug the following changes were made:
- Improved exception reporting from runner.
- Updated AMQ examples to use a default AMQP url of None.
- Changed default AMQP address to an IPv4 address instead of ``localhost`` which results in IPv4 and IPv6 addresses being used. This was causing additional unnecessary content in error reports. Tests needed to be updated to support this change.
- Changed project status to Beta.
- Bumped version.
- Update to resolve type check warning
- Style updates using black.
