### PR TITLE
Support python3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+venv*/
 
 # Spyder project settings
 .spyderproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ language: python
 python:
   - 3.6
   - 3.7
+  - 3.8
 os:
   - linux
 git:

--- a/examples/amq/rpc/rpc-client.py
+++ b/examples/amq/rpc/rpc-client.py
@@ -46,15 +46,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     r = Requester(

--- a/examples/amq/rpc/rpc-server.py
+++ b/examples/amq/rpc/rpc-server.py
@@ -13,7 +13,8 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def get_options():
+if __name__ == "__main__":
+
     parser = argparse.ArgumentParser(description="AMQP RPC Server Example")
     parser.add_argument(
         "--amqp-url", metavar="<url>", type=str, default=None, help="The AMQP URL"
@@ -40,22 +41,12 @@ def get_options():
         help="Logging level. Default is 'error'.",
     )
 
-    return parser.parse_args()
-
-
-if __name__ == "__main__":
-
-    args = get_options()
-
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
+    args = parser.parse_args()
 
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     async def on_request(payload: Any, message: IncomingMessage):

--- a/examples/datagram/base/receiver.py
+++ b/examples/datagram/base/receiver.py
@@ -34,15 +34,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     def on_message(self, data, **kwargs) -> None:

--- a/examples/datagram/base/sender.py
+++ b/examples/datagram/base/sender.py
@@ -35,15 +35,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     s = DatagramEndpoint(content_type=CONTENT_TYPE_JSON)

--- a/examples/datagram/broadcast/receiver.py
+++ b/examples/datagram/broadcast/receiver.py
@@ -34,15 +34,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     def on_message(self, data, **kwargs) -> None:

--- a/examples/datagram/broadcast/sender.py
+++ b/examples/datagram/broadcast/sender.py
@@ -39,15 +39,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     s = DatagramEndpoint(content_type=CONTENT_TYPE_JSON)

--- a/examples/datagram/mti/receiver.py
+++ b/examples/datagram/mti/receiver.py
@@ -35,15 +35,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     def on_message(self, data, **kwargs) -> None:

--- a/examples/datagram/mti/sender.py
+++ b/examples/datagram/mti/sender.py
@@ -36,15 +36,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     s = MtiDatagramEndpoint(content_type=CONTENT_TYPE_PROTOBUF)

--- a/examples/stream/linereceiver/client.py
+++ b/examples/stream/linereceiver/client.py
@@ -35,15 +35,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     def on_started(client):

--- a/examples/stream/linereceiver/server.py
+++ b/examples/stream/linereceiver/server.py
@@ -35,15 +35,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     def on_started(server):
@@ -56,7 +51,7 @@ if __name__ == "__main__":
         print(f"Server peer {peer_id} connected")
 
     def on_peer_unavailable(server, peer_id):
-        print(f"Server peer {peer_id} connected")
+        print(f"Server peer {peer_id} disconnected")
 
     async def on_message(server, data, peer_id, **kwargs) -> None:
         msg = data.decode()

--- a/examples/stream/mti/client.py
+++ b/examples/stream/mti/client.py
@@ -36,15 +36,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     def on_started(client):

--- a/examples/stream/mti/server.py
+++ b/examples/stream/mti/server.py
@@ -36,15 +36,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     def on_started(server):
@@ -57,7 +52,7 @@ if __name__ == "__main__":
         print(f"Server peer {peer_id} connected")
 
     def on_peer_unavailable(server, peer_id):
-        print(f"Server peer {peer_id} connected")
+        print(f"Server peer {peer_id} disconnected")
 
     async def on_message(server, data, peer_id, **kwargs) -> None:
         print(f"Server received msg from {peer_id}: {data}")

--- a/examples/stream/netstring/client.py
+++ b/examples/stream/netstring/client.py
@@ -28,21 +28,17 @@ if __name__ == "__main__":
     parser.add_argument(
         "--log-level",
         type=str,
+        choices=["debug", "info", "error"],
         default="error",
         help="Logging level [debug|info|error]. Default is 'error'.",
     )
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     def on_started(client):

--- a/examples/stream/netstring/server.py
+++ b/examples/stream/netstring/server.py
@@ -28,21 +28,17 @@ if __name__ == "__main__":
     parser.add_argument(
         "--log-level",
         type=str,
+        choices=["debug", "info", "error"],
         default="error",
         help="Logging level [debug|info|error]. Default is 'error'.",
     )
 
     args = parser.parse_args()
 
-    try:
-        numeric_level = getattr(logging, args.log_level.upper())
-    except ValueError:
-        raise Exception(f"Invalid log-level: {args.log_level}")
-
     logging.basicConfig(
         format="%(asctime)s.%(msecs)03.0f [%(levelname)s] [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=numeric_level,
+        level=getattr(logging, args.log_level.upper()),
     )
 
     def on_started(server):
@@ -55,7 +51,7 @@ if __name__ == "__main__":
         print(f"Server peer {peer_id} connected")
 
     def on_peer_unavailable(server, peer_id):
-        print(f"Server peer {peer_id} connected")
+        print(f"Server peer {peer_id} disconnected")
 
     async def on_message(server, data, peer_id, **kwargs) -> None:
         print(f"Server received msg from {peer_id}: {data}")

--- a/src/gestalt/amq/requester.py
+++ b/src/gestalt/amq/requester.py
@@ -344,7 +344,7 @@ class Requester(object):
             logger.warning(f"Unknown message was returned: {message}")
             return
 
-        f.set_exception(DeliveryError(message, None))
+        f.set_exception(DeliveryError(message, None))  # type: ignore
 
     def _on_reconnected(self):
         logger.debug("Reconnected to broker!")

--- a/src/gestalt/stream/protocols/base.py
+++ b/src/gestalt/stream/protocols/base.py
@@ -110,7 +110,8 @@ class BaseStreamProtocol(asyncio.Protocol):
         logger.debug(
             f"Connection lost. id={self._identity}, "
             f"laddr={self._local_address}, "
-            f"raddr={self._remote_address}"
+            f"raddr={self._remote_address}, "
+            f"reason={exc}"
         )
 
         # Don't let user code break the library

--- a/tests/test_stream_netstring.py
+++ b/tests/test_stream_netstring.py
@@ -9,13 +9,14 @@ import unittest.mock
 from gestalt.stream.netstring import NetstringStreamClient, NetstringStreamServer
 import tls_utils
 
+
 py_ver = sys.version_info
 PY36 = py_ver.major == 3 and py_ver.minor == 6
-PY37 = py_ver.major == 3 and py_ver.minor == 7
 
 
 class NetstringStreamEndpointTestCase(asynctest.TestCase):
     async def test_start_server(self):
+        """ Check a Netstring server can be started """
         server_on_message_mock = unittest.mock.Mock()
         server_on_started_mock = unittest.mock.Mock()
         server_on_stopped_mock = unittest.mock.Mock()
@@ -32,19 +33,30 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
 
         await server_ep.start()
         self.assertTrue(server_on_started_mock.called)
+        (args, kwargs) = server_on_started_mock.call_args
+        self.assertIs(args[0], server_ep)
+        server_on_started_mock.reset_mock()
 
+        self.assertTrue(server_ep.running)
         address, port = server_ep.bindings[0]
 
         # Check that starting a server that is already started does not
         # have any consequences
         await server_ep.start()
+        self.assertFalse(server_on_started_mock.called)
 
         await server_ep.stop()
         self.assertTrue(server_on_stopped_mock.called)
+        (args, kwargs) = server_on_stopped_mock.call_args
+        self.assertIs(args[0], server_ep)
+        server_on_stopped_mock.reset_mock()
+
+        self.assertFalse(server_ep.running)
 
         # Check that stopping a server that is already stopped does not
         # have any consequences
         await server_ep.stop()
+        self.assertFalse(server_on_stopped_mock.called)
 
     async def test_start_server_on_unavailable_port(self):
         """ check starting server on a used port raises an exception """
@@ -74,9 +86,12 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
                     await server_ep.start(addr=host, port=occupied_port)
 
             self.assertFalse(server_on_started_mock.called)
+            self.assertFalse(server_ep.running)
 
+            # Server was never started so calling stop should not have any
+            # consequences
             await server_ep.stop()
-            self.assertTrue(server_on_stopped_mock.called)
+            self.assertFalse(server_on_stopped_mock.called)
         finally:
             listener.close()
             await listener.wait_closed()
@@ -96,7 +111,7 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
             ("127.0.0.1", "Using 127.0.0.1 as address"),
         )
 
-        # Attempt connection with reconnect=True
+        # Attempt connection with default reconnect=True
         for addr_value, subtest_description in sub_tests:
             with self.subTest(subtest_description):
                 with self.assertLogs(
@@ -104,10 +119,9 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
                 ) as log:
                     await client_ep.start(addr=addr_value, port=5555)
                     # wait briefly for a reconnect attempt
-                    await asyncio.sleep(0.1)
+                    await asyncio.sleep(0.05)
                     expected_items = (
                         "was refused",
-                        "Attempting reconnect in",
                         "seconds before connection attempt",
                     )
                     for expected_item in expected_items:
@@ -123,19 +137,16 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
                 with self.assertLogs(
                     "gestalt.stream.endpoint", level=logging.DEBUG
                 ) as log:
-                    await client_ep.start(addr="127.0.0.1", port=5555, reconnect=False)
+                    await client_ep.start(addr=addr_value, port=5555, reconnect=False)
                     # wait briefly for a possible reconnect attempt
-                    await asyncio.sleep(0.1)
+                    await asyncio.sleep(0.05)
                     expected_items = ("was refused",)
                     for expected_item in expected_items:
                         self.assertTrue(
                             any(expected_item in log_item for log_item in log.output)
                         )
 
-                    unexpected_items = (
-                        "Attempting reconnect in",
-                        "seconds before connection attempt",
-                    )
+                    unexpected_items = ("seconds before connection attempt",)
                     for expected_item in unexpected_items:
                         self.assertFalse(
                             any(expected_item in log_item for log_item in log.output)
@@ -249,17 +260,20 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
         server_ctx = tls_utils.create_ssl_server_context(*server_certs)
 
         # Create a client context where the root CA is not loaded. This should
-        # prevent client from authenticating server.
+        # prevent the client from authenticating with the server.
         client_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
         client_ctx.set_ciphers("ECDH+AESGCM")
         client_ctx.load_cert_chain(
             certfile=certificates.client_cert, keyfile=certificates.client_key
         )
+        # Typically the CA would be loaded but this test skips that.
         # client_ctx.load_verify_locations(cafile=certificates.ca_cert)
         client_ctx.check_hostname = True
-        client_ctx.options |= (
-            ssl.PROTOCOL_TLSv1_1 | ssl.OP_NO_COMPRESSION  # selects older version
-        )
+        if PY36:
+            client_ctx.options |= ssl.PROTOCOL_TLS | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+        else:
+            client_ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+            client_ctx.maximum_version = ssl.TLSVersion.TLSv1_2
 
         server_on_started_mock = asynctest.CoroutineMock()
         server_on_stopped_mock = asynctest.CoroutineMock()
@@ -276,59 +290,21 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
         client_ep = NetstringStreamClient()
 
         try:
-            if PY36:
-                with self.assertLogs(
-                    "gestalt.stream.endpoint", level=logging.ERROR
-                ) as log:
-                    await client_ep.start(
-                        addr=address,
-                        port=port,
-                        family=socket.AF_INET,
-                        ssl=client_ctx,
-                        reconnect=False,
+            with self.assertLogs("gestalt.stream.endpoint", level=logging.ERROR) as log:
+                await client_ep.start(
+                    addr=address,
+                    port=port,
+                    family=socket.AF_INET,
+                    ssl=client_ctx,
+                    reconnect=False,
+                )
+                await asyncio.sleep(0.1)
+
+                expected_items = ("was refused",)
+                for expected_item in expected_items:
+                    self.assertTrue(
+                        any(expected_item in log_item for log_item in log.output)
                     )
-                    await asyncio.sleep(0.1)
-
-                    expected_items = ("was refused", "certificate verify failed")
-                    for expected_item in expected_items:
-                        self.assertTrue(
-                            any(expected_item in log_item for log_item in log.output)
-                        )
-            else:
-                # suppress ssl exception traceback logs reporting
-                # "certificate verify failed: self signed certificate in certificate chain"
-                with self.assertLogs(level=logging.ERROR) as root_log:
-                    with self.assertLogs(
-                        "gestalt.stream.endpoint", level=logging.ERROR
-                    ) as log:
-                        await client_ep.start(
-                            addr=address,
-                            port=port,
-                            family=socket.AF_INET,
-                            ssl=client_ctx,
-                            reconnect=False,
-                        )
-                        await asyncio.sleep(0.1)
-
-                        expected_items = ("was refused", "certificate verify failed")
-                        for expected_item in expected_items:
-                            self.assertTrue(
-                                any(
-                                    expected_item in log_item for log_item in log.output
-                                )
-                            )
-
-                        # In Python 3.7+ Errors get sent to root logger
-                        expected_items = (
-                            "certificate verify failed: self signed certificate in certificate chain",
-                        )
-                        for expected_item in expected_items:
-                            self.assertTrue(
-                                any(
-                                    expected_item in log_item
-                                    for log_item in root_log.output
-                                )
-                            )
 
         finally:
             await client_ep.stop()
@@ -349,26 +325,30 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
         )
         server_ctx = tls_utils.create_ssl_server_context(*server_certs)
 
-        # Create a client context where the root CA is not loaded. This should
-        # prevent client from authenticating server.
+        # Create a client context where the client certificates are not loaded.
+        # This should prevent the client from authenticating with the server.
         client_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
         client_ctx.set_ciphers("ECDH+AESGCM")
+        # Typically the client certs would be loaded but this test skips that.
         # client_ctx.load_cert_chain(
         #    certfile=certificates.client_cert, keyfile=certificates.client_key)
         client_ctx.load_verify_locations(cafile=certificates.ca_cert)
         client_ctx.check_hostname = True
-        client_ctx.options |= (
-            ssl.PROTOCOL_TLS
-            | ssl.OP_NO_TLSv1  # This selects the highest support version
-            | ssl.OP_NO_TLSv1_1
-            | ssl.OP_NO_COMPRESSION
-        )
+        if PY36:
+            client_ctx.options |= ssl.PROTOCOL_TLS | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+        else:
+            client_ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+            client_ctx.maximum_version = ssl.TLSVersion.TLSv1_2
 
         server_on_started_mock = asynctest.CoroutineMock()
         server_on_stopped_mock = asynctest.CoroutineMock()
-
+        server_on_peer_available_mock = asynctest.CoroutineMock()
+        server_on_peer_unavailable_mock = asynctest.CoroutineMock()
         server_ep = NetstringStreamServer(
-            on_started=server_on_started_mock, on_stopped=server_on_stopped_mock
+            on_started=server_on_started_mock,
+            on_stopped=server_on_stopped_mock,
+            on_peer_available=server_on_peer_available_mock,
+            on_peer_unavailable=server_on_peer_unavailable_mock,
         )
 
         await server_ep.start(addr="127.0.0.1", family=socket.AF_INET, ssl=server_ctx)
@@ -376,59 +356,32 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
 
         address, port = server_ep.bindings[0]
 
-        client_ep = NetstringStreamClient()
-
+        client_on_peer_available_mock = asynctest.CoroutineMock()
+        client_on_peer_unavailable_mock = asynctest.CoroutineMock()
+        client_ep = NetstringStreamClient(
+            on_peer_available=client_on_peer_available_mock,
+            on_peer_unavailable=client_on_peer_unavailable_mock,
+        )
         try:
-            if PY36:
-                with self.assertLogs(
-                    "gestalt.stream.endpoint", level=logging.ERROR
-                ) as log:
-                    await client_ep.start(
-                        addr=address,
-                        port=port,
-                        family=socket.AF_INET,
-                        ssl=client_ctx,
-                        reconnect=False,
+            with self.assertLogs("gestalt.stream.endpoint", level=logging.ERROR) as log:
+                await client_ep.start(
+                    addr=address,
+                    port=port,
+                    family=socket.AF_INET,
+                    ssl=client_ctx,
+                    reconnect=False,
+                )
+                await asyncio.sleep(0.1)
+
+                self.assertFalse(server_on_peer_available_mock.called)
+                self.assertFalse(client_on_peer_available_mock.called)
+
+                expected_items = ("was refused",)
+                for expected_item in expected_items:
+                    self.assertTrue(
+                        any(expected_item in log_item for log_item in log.output)
                     )
-                    await asyncio.sleep(0.1)
 
-                    expected_items = ("was refused",)
-                    for expected_item in expected_items:
-                        self.assertTrue(
-                            any(expected_item in log_item for log_item in log.output)
-                        )
-
-            else:
-                with self.assertLogs(level=logging.ERROR) as root_log:
-                    with self.assertLogs(
-                        "gestalt.stream.endpoint", level=logging.ERROR
-                    ) as log:
-                        await client_ep.start(
-                            addr=address,
-                            port=port,
-                            family=socket.AF_INET,
-                            ssl=client_ctx,
-                            reconnect=False,
-                        )
-                        await asyncio.sleep(0.1)
-
-                        expected_items = ("was refused",)
-                        for expected_item in expected_items:
-                            self.assertTrue(
-                                any(
-                                    expected_item in log_item for log_item in log.output
-                                )
-                            )
-
-                        # In Python 3.7+ Errors get sent to root logger
-                        expected_items = ("peer did not return a certificate",)
-                        for expected_item in expected_items:
-                            self.assertTrue(
-                                any(
-                                    expected_item in log_item
-                                    for log_item in root_log.output
-                                )
-                            )
         finally:
             await client_ep.stop()
             await asyncio.sleep(0.1)
@@ -438,7 +391,7 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
 
     @unittest.skipUnless(tls_utils.CERTS_EXIST, "cert files do not exist")
     async def test_client_server_ssl_with_selfsigned_client_certificates(self):
-        """ check server correctly fails to verify client not supplying a certificate """
+        """ check server correctly fails to verify client supplying a self signed certificate """
         certificates = tls_utils.get_certs()
 
         server_certs = (
@@ -448,22 +401,22 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
         )
         server_ctx = tls_utils.create_ssl_server_context(*server_certs)
 
-        # Create a client context where the root CA is not loaded. This should
-        # prevent client from authenticating server.
+        # Create a client context where self-signed certificates are loaded.
+        # This should prevent client from authenticating with the server.
         client_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
         client_ctx.set_ciphers("ECDH+AESGCM")
-        # Load client certs that were self signed (not signed by root CA)
+        # Load alternative client certs that were self signed (not signed by root CA)
         client_cert = certificates.client_cert.replace("client", "client2")
         client_key = certificates.client_key.replace("client", "client2")
         client_ctx.load_cert_chain(certfile=client_cert, keyfile=client_key)
         client_ctx.load_verify_locations(cafile=certificates.ca_cert)
         client_ctx.check_hostname = True
-        client_ctx.options |= (
-            ssl.PROTOCOL_TLS
-            | ssl.OP_NO_TLSv1  # This selects the highest support version
-            | ssl.OP_NO_TLSv1_1
-            | ssl.OP_NO_COMPRESSION
-        )
+
+        if PY36:
+            client_ctx.options |= ssl.PROTOCOL_TLS | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+        else:
+            client_ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+            client_ctx.maximum_version = ssl.TLSVersion.TLSv1_2
 
         server_on_started_mock = asynctest.CoroutineMock()
         server_on_stopped_mock = asynctest.CoroutineMock()
@@ -480,55 +433,21 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
         client_ep = NetstringStreamClient()
 
         try:
-            if PY36:
-                with self.assertLogs(
-                    "gestalt.stream.endpoint", level=logging.ERROR
-                ) as log:
-                    await client_ep.start(
-                        addr=address, port=port, family=socket.AF_INET, ssl=client_ctx
+            with self.assertLogs("gestalt.stream.endpoint", level=logging.ERROR) as log:
+                await client_ep.start(
+                    addr=address,
+                    port=port,
+                    family=socket.AF_INET,
+                    ssl=client_ctx,
+                    reconnect=False,
+                )
+                await asyncio.sleep(0.1)
+
+                expected_items = ("was refused",)
+                for expected_item in expected_items:
+                    self.assertTrue(
+                        any(expected_item in log_item for log_item in log.output)
                     )
-                    await asyncio.sleep(0.1)
-
-                    expected_items = ("was refused",)
-                    for expected_item in expected_items:
-                        self.assertTrue(
-                            any(expected_item in log_item for log_item in log.output)
-                        )
-            else:
-
-                with self.assertLogs(level=logging.ERROR) as root_log:
-                    with self.assertLogs(
-                        "gestalt.stream.endpoint", level=logging.ERROR
-                    ) as log:
-                        await client_ep.start(
-                            addr=address,
-                            port=port,
-                            family=socket.AF_INET,
-                            ssl=client_ctx,
-                        )
-                        await asyncio.sleep(0.1)
-
-                        expected_items = ("was refused",)
-                        for expected_item in expected_items:
-                            self.assertTrue(
-                                any(
-                                    expected_item in log_item for log_item in log.output
-                                )
-                            )
-
-                        # In Python 3.7+ Errors get sent to root logger
-                        # Errors reported to root logger are possibly related to:
-                        # https://stackoverflow.com/questions/52012488/ssl-asyncio-traceback-even-when-error-is-handled
-                        expected_items = (
-                            "certificate verify failed: self signed certificate",
-                        )
-                        for expected_item in expected_items:
-                            self.assertTrue(
-                                any(
-                                    expected_item in log_item
-                                    for log_item in root_log.output
-                                )
-                            )
 
         finally:
             await client_ep.stop()


### PR DESCRIPTION
This merge request updates the package to support Python3.8.

The main differences observed when testing with Python3.8 were in the lack of OSErrors raised by the ssl package. Differences in this area were previously observed between Python3.6 and Python3.7 and the unit tests had version specific blocks to handle Python3.6 and others (at the time only Python3.7).

I initially noticed differences between Python3.7 and Python3.8 but this was because I was running an older point release of Python3.7. It appears that the ssl package and the bundled version of OpenSSL were updated in the latest releases of Python3.7 and Python3.8 so Python3.7 and Python3.8 behave similarly.

Modifications:
- The TravisCI file was updated to include Python3.8.
- Updated unit tests related to TLS.
- The streaming endpoint behaviour was slightly modified as a result of more thorough testing related to tls connection errors which came about through investigations of differences between the Python versions.
 
Other changes made while working through the issues are:
- Minor docs fixes
- Improve examples by simplifying logging level configuration.