### PR TITLE
Fix msg_len to be included in the class scope

### DIFF
--- a/src/gestalt/stream/protocols/netstring.py
+++ b/src/gestalt/stream/protocols/netstring.py
@@ -57,6 +57,7 @@ class NetstringStreamProtocol(BaseStreamProtocol):
         )
         self._buffer = bytearray()
         self._state = ProtocolStates.WAIT_HEADER
+        self.msg_len = 0  # Default to 0
 
     def send(
         self, data: bytes, add_frame_header=True, **kwargs
@@ -101,14 +102,14 @@ class NetstringStreamProtocol(BaseStreamProtocol):
                     # Remember that msg_len value represents the length of
                     # the payload, not the total message length which has the
                     # frame header too.
-                    msg_len = struct.unpack(
+                    self.msg_len = struct.unpack(
                         NETSTRING_HEADER_FORMAT, self._buffer[:NETSTRING_HEADER_SIZE]
                     )[0]
 
-                    if msg_len == 0 or msg_len > MAX_MSG_SIZE:
+                    if self.msg_len == 0 or self.msg_len > MAX_MSG_SIZE:
                         # msg has no body or is too big
                         logger.error(
-                            f"Msg size ({msg_len}) is zero or exceeds maximum msg size. "
+                            f"Msg size ({self.msg_len}) is zero or exceeds maximum msg size. "
                             f"Disconnecting peer {self._identity}."
                         )
                         self.close()
@@ -122,7 +123,7 @@ class NetstringStreamProtocol(BaseStreamProtocol):
                     break
 
             elif self._state == ProtocolStates.WAIT_PAYLOAD:
-                eom = NETSTRING_HEADER_SIZE + msg_len
+                eom = NETSTRING_HEADER_SIZE + self.msg_len
                 if len(self._buffer) >= eom:
                     msg = bytes(self._buffer[NETSTRING_HEADER_SIZE:eom])
                     self._buffer = self._buffer[eom:]


### PR DESCRIPTION
Hello Chris, if you break out of your loop to allow the buffer to be updated,  you will lose reference to msg_len i purpose you set it as a class variable and keep it in the class scope allowing the reference to be used again in the WAIT_PAYLOAD portion of the data_received function.