### PR TITLE
Fix a bug in msg_len

### DIFF
--- a/tests/test_stream_mti_protocol.py
+++ b/tests/test_stream_mti_protocol.py
@@ -1,0 +1,65 @@
+import logging
+import struct
+import unittest
+import unittest.mock
+
+from gestalt.stream.protocols.mti import MTI_HEADER_FORMAT, MtiStreamProtocol
+
+
+def create_mti_message(msg_id: int, data: bytes) -> bytes:
+    header = struct.pack(MTI_HEADER_FORMAT, len(data), msg_id)
+    msg = header + data
+    return msg
+
+
+class MtiStreamProtocolTestCase(unittest.TestCase):
+    def test_error_raised_when_sending_invalid_data_type(self):
+        p = MtiStreamProtocol()
+        with self.assertLogs(
+            "gestalt.stream.protocols.mti", level=logging.ERROR
+        ) as log:
+            p.send("Hello World")
+        self.assertIn("data must be bytes", log.output[0])
+
+    def test_error_raised_when_using_invalid_type_identifier_data_type(self):
+        p = MtiStreamProtocol()
+        with self.assertLogs(
+            "gestalt.stream.protocols.mti", level=logging.ERROR
+        ) as log:
+            p.send(b"Hello World", type_identifier="abc")
+        self.assertIn("type_identifier must be integer", log.output[0])
+
+    def test_empty_message_can_be_sent(self):
+        p = MtiStreamProtocol()
+        transport_mock = unittest.mock.Mock()
+        p.transport = transport_mock
+
+        p.send(b"")
+
+        self.assertTrue(transport_mock.write.called)
+
+    def test_empty_message_can_be_received(self):
+        on_message_mock = unittest.mock.Mock()
+
+        p = MtiStreamProtocol(on_message=on_message_mock,)
+
+        mti_msg = create_mti_message(42, b"")
+
+        p.data_received(mti_msg)
+
+        self.assertTrue(on_message_mock.called)
+        self.assertEqual(on_message_mock.call_count, 1)
+
+    def test_message_received_in_worst_case_delivery_scenario(self):
+        on_message_mock = unittest.mock.Mock()
+
+        p = MtiStreamProtocol(on_message=on_message_mock,)
+
+        mti_msg = create_mti_message(42, b"Hello World")
+
+        # Send the test message 1 byte at a time
+        for b in mti_msg:
+            p.data_received([b])
+
+        self.assertTrue(on_message_mock.called)
+        self.assertEqual(on_message_mock.call_count, 1)

--- a/tests/test_stream_netstring.py
+++ b/tests/test_stream_netstring.py
@@ -33,12 +33,12 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
 
         await server_ep.start()
         self.assertTrue(server_on_started_mock.called)
-        (args, kwargs) = server_on_started_mock.call_args
+        (args, _kwargs) = server_on_started_mock.call_args
         self.assertIs(args[0], server_ep)
         server_on_started_mock.reset_mock()
 
         self.assertTrue(server_ep.running)
-        address, port = server_ep.bindings[0]
+        _address, _port = server_ep.bindings[0]
 
         # Check that starting a server that is already started does not
         # have any consequences
@@ -81,7 +81,7 @@ class NetstringStreamEndpointTestCase(asynctest.TestCase):
                 on_peer_unavailable=server_on_peer_unavailable_mock,
             )
 
-            with self.assertLogs("gestalt.stream.endpoint", level=logging.ERROR) as log:
+            with self.assertLogs("gestalt.stream.endpoint", level=logging.ERROR):
                 with self.assertRaises(Exception):
                     await server_ep.start(addr=host, port=occupied_port)
 

--- a/tests/test_stream_netstring_protocol.py
+++ b/tests/test_stream_netstring_protocol.py
@@ -1,0 +1,73 @@
+import logging
+import struct
+import unittest
+import unittest.mock
+
+from gestalt.stream.protocols.netstring import (
+    NETSTRING_HEADER_FORMAT,
+    NetstringStreamProtocol,
+)
+
+
+def create_netstring_message(data: bytes) -> bytes:
+    header = struct.pack(NETSTRING_HEADER_FORMAT, len(data))
+    msg = header + data
+    return msg
+
+
+class NetstringStreamProtocolTestCase(unittest.TestCase):
+    def test_error_raised_when_sending_invalid_data_type(self):
+        p = NetstringStreamProtocol()
+        with self.assertLogs(
+            "gestalt.stream.protocols.netstring", level=logging.ERROR
+        ) as log:
+            p.send("Hello World")
+        self.assertIn("data must be bytes", log.output[0])
+
+    def test_error_raised_when_sending_empty_message(self):
+        p = NetstringStreamProtocol()
+        transport_mock = unittest.mock.Mock()
+        p.transport = transport_mock
+
+        with self.assertLogs(
+            "gestalt.stream.protocols.netstring", level=logging.ERROR
+        ) as log:
+            p.send(b"")
+        self.assertIn("data must contain at least 1 byte", log.output[0])
+
+        self.assertFalse(transport_mock.write.called)
+
+    def test_error_raised_when_received_an_empty_message(self):
+        on_message_mock = unittest.mock.Mock()
+        close_mock = unittest.mock.Mock()
+
+        p = NetstringStreamProtocol(on_message=on_message_mock,)
+        p.close = close_mock
+
+        netstring_msg = create_netstring_message(b"")
+
+        # An empty message is considered invalid
+        with self.assertLogs(
+            "gestalt.stream.protocols.netstring", level=logging.ERROR
+        ) as log:
+            p.data_received(netstring_msg)
+        self.assertIn("is zero", log.output[0])
+
+        self.assertFalse(on_message_mock.called)
+
+        # Error scenario should trigger the protocol to close the connection
+        self.assertTrue(close_mock.called)
+
+    def test_message_received_in_worst_case_delivery_scenario(self):
+        on_message_mock = unittest.mock.Mock()
+
+        p = NetstringStreamProtocol(on_message=on_message_mock,)
+
+        netstring_msg = create_netstring_message(b"Hello World")
+
+        # Send the test message 1 byte at a time
+        for b in netstring_msg:
+            p.data_received([b])
+
+        self.assertTrue(on_message_mock.called)
+        self.assertEqual(on_message_mock.call_count, 1)


### PR DESCRIPTION
This merge request provides a more complete solution to the issue and proposed fix raised in #7.

When a message is received in parts then one or more variables may not be set to the correct value. The fix is to change the variables to member attributes so that their state is retained over mulitple calls.

This merge request also adds some unittests that verify the proposed change works as intended.  