### PR TITLE
Correctly indicate package supports Python3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ if __name__ == "__main__":
             "Intended Audience :: Developers",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: Implementation :: CPython",
         ],
         keywords=["gestalt", "framework", "communications"],

--- a/src/gestalt/__init__.py
+++ b/src/gestalt/__init__.py
@@ -2,4 +2,4 @@
 Gestalt is a Python application framework for building distributed systems.
 """
 
-__version__ = "20.1.0"
+__version__ = "20.1.1"


### PR DESCRIPTION
The pyversion badge displayed on the README page does not indicate the package supports Python3.8.

This merge requests updates the ``setup.py`` to include a Python 3.8 classifier line. This information is used when generating the badge that is displayed on the README. It should then accurately report that the package also supports Python 3.8.

Also bump the version so a new release can be pushed to PyPI. The pyversion badge is generated from the package data stored at PyPI